### PR TITLE
Skip events with empty LHE weights for samples that should have them

### DIFF
--- a/NtupleProducer/plugins/HTauTauNtuplizer.cc
+++ b/NtupleProducer/plugins/HTauTauNtuplizer.cc
@@ -797,6 +797,7 @@ class HTauTauNtuplizer : public edm::EDAnalyzer {
   unsigned _MC_pdf_first_idx;
   unsigned _MC_pdf_last_idx;
   std::vector<unsigned> _MC_QCDscale_indices = std::vector<unsigned>(7, 0);
+  int empty_lheweights = 0;
 };
 
 const int HTauTauNtuplizer::ntauIds; // definition of static member
@@ -2129,6 +2130,10 @@ void HTauTauNtuplizer::analyze(const edm::Event& event, const edm::EventSetup& e
     if (lheeventinfo.isValid()) {
       _nup=lheeventinfo->hepeup().NUP;
       auto lheweights = lheeventinfo->weights();
+      if(lheweights.size() == 0) { // skip rare cases where LHE weights are empty for individual events
+        empty_lheweights++;
+        return;
+      }
       for (unsigned pdf_idx = _MC_pdf_first_idx; pdf_idx <= _MC_pdf_first_idx+_MC_pdf_last_idx; ++pdf_idx) {
         if (pdf_idx != _MC_pdf_first_idx) {
           _MC_pdf[pdf_idx-_MC_pdf_first_idx] = st_mult * lheweights[pdf_idx].wgt;
@@ -3827,7 +3832,7 @@ void HTauTauNtuplizer::endJob(){
     for(int i=1;i<=ntauIds;i++){
     hTauIDs->GetXaxis()->SetBinLabel(i,tauIDStrings[i-1].Data());
   }
-
+  std::cout<<"Skipped events due to empty lhe weights: "<<empty_lheweights<<std::endl;
 }
 
 

--- a/NtupleProducer/plugins/HTauTauNtuplizer.cc
+++ b/NtupleProducer/plugins/HTauTauNtuplizer.cc
@@ -3832,7 +3832,7 @@ void HTauTauNtuplizer::endJob(){
     for(int i=1;i<=ntauIds;i++){
     hTauIDs->GetXaxis()->SetBinLabel(i,tauIDStrings[i-1].Data());
   }
-  std::cout<<"Skipped events due to empty lhe weights: "<<empty_lheweights<<std::endl;
+  if(empty_lheweights > 0) std::cout<<"Skipped events due to empty lhe weights: "<<empty_lheweights<<std::endl;
 }
 
 


### PR DESCRIPTION
Some files of the LHE Z pT binned samples in 2017 (other eras were not checked yet) have events for which the LHE weights are empty, although the samples should have them in general. Since these seem to be only a few files and only a few events for these files, this PR adds the code to skip these events